### PR TITLE
feat: Add Input component with validation support

### DIFF
--- a/fajbr/Resources/Localizable.xcstrings
+++ b/fajbr/Resources/Localizable.xcstrings
@@ -1,7 +1,21 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "Hello, Fajbr!" : {
+    "" : {
+
+    },
+    "preview_sugar_does_not_contain_fiber" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sugar does not contain fiber. Try something else."
+          }
+        }
+      }
+    },
+    "Username is required" : {
 
     }
   },

--- a/fajbr/Sources/Presentation/Shared/Components/Input/Input.swift
+++ b/fajbr/Sources/Presentation/Shared/Components/Input/Input.swift
@@ -1,0 +1,116 @@
+//
+// Created with ❤️ by Daniel Gabzdyl.
+
+import SwiftUI
+
+
+struct Input: View {
+    
+    enum InputState {
+        case initial
+        case valid
+        case invalid(LocalizedStringKey)
+    }
+    
+    
+    // MARK: - Input
+    
+    @Binding var text: String
+    let placeholder: String = ""
+    let validation: Validation?
+    
+    
+    // MARK: - State
+    
+    @State private var state: InputState = .initial
+    
+    
+    // MARK: - Computed properties
+    
+    var strokeColor: Color {
+        switch state {
+        case .valid:
+            return .featherGreen
+        case .invalid:
+            return .cardinal
+        default:
+            return .clear
+        }
+    }
+    
+    var message: LocalizedStringKey {
+        switch state {
+        case .invalid(let message):
+            return message
+        default:
+            return ""
+        }
+    }
+    
+    
+    // MARK: - Body
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            TextField(placeholder, text: $text)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .padding()
+                .background(.polar)
+                .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .stroke(strokeColor, lineWidth: 1)
+                )
+                .onChange(of: text) { _, current in
+                    validate(text: current)
+                }
+            
+            Text(message)
+                .lineLimit(1, reservesSpace: true)
+                .font(.caption)
+                .foregroundColor(.cardinal)
+                .fixedSize()
+        }
+        .padding()
+        .onAppear {
+            guard text.isEmpty == false else {
+                return
+            }
+            
+            validate(text: text)
+        }
+    }
+    
+    
+    // MARK: - Private functions
+    
+    private func validate(text: String) {
+        guard let validation else {
+            return
+        }
+        
+        if let error = validation.perform(input: text) {
+            state = .invalid(error.message)
+        } else {
+            state = .valid
+        }
+    }
+}
+
+
+#Preview("No Validation", traits: .sizeThatFitsLayout) {
+    Input(text: .constant("🥕 Carrot"), validation: nil)
+}
+
+#Preview("Valid", traits: .sizeThatFitsLayout) {
+    Input(text: .constant("🥬 Cabbage"), validation: Validation { _ in
+        return nil
+    })
+}
+
+#Preview("Invalid", traits: .sizeThatFitsLayout) {
+    Input(text: .constant("🍩 Sugar"), validation: Validation { _ in
+        return .forMessage("preview_sugar_does_not_contain_fiber")
+    })
+}

--- a/fajbr/Sources/Presentation/Shared/Components/Input/Validation.swift
+++ b/fajbr/Sources/Presentation/Shared/Components/Input/Validation.swift
@@ -1,0 +1,36 @@
+//
+// Created with ❤️ by Daniel Gabzdyl.
+
+import SwiftUI
+
+
+class Validation {
+
+    struct Error {
+        let message: LocalizedStringKey
+
+        static func forMessage(_ message: LocalizedStringKey) -> Error {
+            Error(message: message)
+        }
+    }
+
+
+    // MARK: - Private properties
+
+    private var validationBlock: (String) -> Error?
+
+
+    // MARK: - Initialization
+
+    init(_ block: @escaping ((String) -> Error?)) {
+        validationBlock = block
+    }
+
+
+    // MARK: - Internal methods
+
+    internal func perform(input: String) -> Error? {
+        validationBlock(input)
+    }
+
+}


### PR DESCRIPTION
## 🔖 Description
Create reusable Input component that handles:
- Input validation
- Validation error states

## 💡 What’s new?
- `Input` component

<img width="341" alt="Screenshot 2025-02-15 at 22 23 27" src="https://github.com/user-attachments/assets/3ded84f6-26bd-453e-ba2e-886fa5e00663" />

<img width="339" alt="Screenshot 2025-02-15 at 22 23 40" src="https://github.com/user-attachments/assets/bc64b4f6-fd94-490c-9921-bcfcec043216" />

<img width="340" alt="Screenshot 2025-02-15 at 22 23 57" src="https://github.com/user-attachments/assets/8a907676-6333-4cd9-9770-9d59cc2efa38" />

## 🤔 What's missing?
- Password (hidden text) support