### PR TITLE
feat: Add simple RoundedButton component

### DIFF
--- a/fajbr/Sources/Presentation/Shared/Components/RoundedButton/RoundedButton.swift
+++ b/fajbr/Sources/Presentation/Shared/Components/RoundedButton/RoundedButton.swift
@@ -1,0 +1,47 @@
+//
+// Created with ❤️ by Daniel Gabzdyl.
+
+import SwiftUI
+
+
+struct RoundedButton: View {
+    
+    // MARK: - Input
+    
+    var title: LocalizedStringKey
+    var fillColor: Color
+    var action: () -> Void
+    
+    
+    // MARK: - Body
+    
+    var body: some View {
+        Button {
+            action()
+        } label: {
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(fillColor)
+                .padding(.horizontal)
+                .overlay {
+                    Text(title)
+                        .foregroundColor(.white)
+                        .font(.headline)
+                }
+        }
+        .frame(height: 44)
+    }
+}
+
+
+#Preview(traits: .sizeThatFitsLayout) {
+    Group {
+        RoundedButton(title: "submit", fillColor: .beetle) { }
+        
+        HStack(spacing: 0) {
+            RoundedButton(title: "confirm", fillColor: .featherGreen) { }
+            
+            RoundedButton(title: "reject", fillColor: .cardinal) { }
+        }
+    }
+    .padding(.vertical)
+}


### PR DESCRIPTION
## 🔖 Description
Create reusable `RoundedButton` component that takes:
- `action`: Callback
- `title`: Localized Key
- `fillColor`: Button's background color

## 💡 What’s new?
- `RoundedButton` component

<img width="329" alt="image" src="https://github.com/user-attachments/assets/d2f90719-d582-4a8d-8b55-d3768f82e738" />

## 🤔 What's missing?
- icon support
- stroke support